### PR TITLE
Fix #37: Fix erroneous MLE estimate when self-edges are included

### DIFF
--- a/openff/arsenic/stats.py
+++ b/openff/arsenic/stats.py
@@ -146,6 +146,8 @@ def mle(
     Xu, Huafengraph. "Optimal measurement network of pairwise differences."
     Journal of Chemical Information and Modeling 59.11 (2019): 4720-4728.
 
+    NOTE: Self-edges (edges that connect a node to itself) will be ignored.
+
     Parameters
     ----------
     graph :nx.Graph
@@ -191,6 +193,9 @@ def mle(
     for (a, b) in graph.edges:
         i = node_name_to_index[a]
         j = node_name_to_index[b]
+        if i == j:
+            # The MLE solver will fail if we include self-edges, so we need to omit these
+            continue
         F_matrix[i, j] = -df_ij[i, j] ** (-2)
         F_matrix[j, i] = -df_ij[i, j] ** (-2)
     for n in graph.nodes:
@@ -209,6 +214,9 @@ def mle(
     for (a, b) in graph.edges:
         i = node_name_to_index[a]
         j = node_name_to_index[b]
+        if i == j:
+            # The MLE solver will fail if we include self-edges, so we need to omit these
+            continue
         z[i] += f_ij[i, j] * df_ij[i, j] ** (-2)
         z[j] += f_ij[j, i] * df_ij[j, i] ** (-2)
 

--- a/openff/arsenic/tests/test_stats.py
+++ b/openff/arsenic/tests/test_stats.py
@@ -34,6 +34,33 @@ def test_mle_easy(input_absolutes: list = [-14.0, -13.0, -9.0]):
          true value: {input_absolutes[i]}."
 
 
+def test_mle_easy_self_edge(input_absolutes: list = [-14.0, -13.0, -9.0]):
+    """
+    Test that the MLE for a graph with an absolute
+    estimate on all nodes will recapitulate it
+    when a self-edge is included
+    """
+
+    graph = nx.DiGraph()
+    for i, val in enumerate(input_absolutes):
+        graph.add_node(i, f_i=val, f_di=0.5)
+
+    edges = [(0, 1), (0, 2), (2, 1), (0,0)]
+    for node1, node2 in edges:
+        noise = np.random.uniform(low=-1.0, high=1.0)
+        diff = input_absolutes[node2] - input_absolutes[node1] + noise
+        graph.add_edge(node1, node2, f_ij=diff, f_dij=0.5 + np.abs(noise))
+
+    output_absolutes, covar = stats.mle(graph, factor="f_ij", node_factor="f_i")
+
+    for i, _ in enumerate(graph.nodes(data=True)):
+        diff = np.abs(output_absolutes[i] - input_absolutes[i])
+        assert (
+            diff < covar[i, i]
+        ), f"MLE error. Output absolute \
+         estimate, {output_absolutes[i]}, is too far from\
+         true value: {input_absolutes[i]}."
+
 def test_mle_hard(input_absolutes: list = [-14.0, -13.0, -9.0]):
     """
     Test that the MLE for a graph with a node missing an absolute value


### PR DESCRIPTION
## Description
This PR fixes issue #37 (Graphs containing self-edges will produce erroneous MLE estimates), and adds a test that failed prior to the fix to verify the issue is resolved.

## Status
- [x] Ready to go